### PR TITLE
Openshift

### DIFF
--- a/src/main/java/de/muenchen/referenzarchitektur/userservice/UserServiceApplication.java
+++ b/src/main/java/de/muenchen/referenzarchitektur/userservice/UserServiceApplication.java
@@ -4,20 +4,16 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
-//import org.springframework.web.cors.CorsConfiguration;
-//import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 /**
  * @author rowe42
  */
 @SpringBootApplication
 @EnableDiscoveryClient
-@ComponentScan("de.muenchen.referenzarchitektur.authorisationLib, de.muenchen.referenzarchitektur.userservice")
 @EnableHypermediaSupport(type = EnableHypermediaSupport.HypermediaType.HAL)
 public class UserServiceApplication {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ security:
     resource:
       filter-order: 3
       jwt:
-        key-value: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqjrVO6S3X8U79FSJgY/zKBvEe+YOYAVRnjeaZLaFs66Amglf1RLp1G2ZANCtEV35uPOWi3ErkQDvGEOn0BNlgxYFI6iPO2co6RnPIRNEIhp7uvw9mxevXmIcRfv0/bulus81ET7H/POYqYpr7zXaN1EQU5nhjsSF39AHC5Xp49Fve8fihtWu63JOd/WnlkxJ+esxl+q+Wx1wBKdY8eaIxrKs3REZV0wxrSq7qwBEgAJ5HAojz3SO/A6s4K/J0Fm1WCxsnkm9LJ+gtnfDltYoJDbZafQyifT45oHz0pApIScqbsvgriOjQxSrQ7XzUx9btMxoKdPHrjlTukGweInqlQIDAQAB
+        key-value: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlsteeVtC+LlM/uhuusceFDvKbeCPolBEpq+rNnRbBvSPDCdKGcIIpjrQswX/58loE/bQ45A5IY1Tlm1MWbGxZ0IZhYaILeTNySTK3aRsV94OpN+ib/PGWkP1aQZ6wdm4//C6whOhCbulbLwSTyjByD72FGdaO/OhrATD9OAEcP0QmrvjLRHQBA80lxB4fRCyIrea9aL/AuvBsAbTz1Ub70rH8ydwaPtev7/L4dY+9NaqoL23pLIYyV7k3cuPeyHU/lt4I68R4rNiFv08zQFWGMr+li13cWNi9KsNfP5h6Ce7h+D2WmOUv7Tm9b8rAJ4jGHuf8ylHWt0SQxBtofuldwIDAQAB
     client:
       client-id: openIdDemo
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     # SPRING_PROFILES_ACTIVE=docker
      # DB: enable web console
     profiles.active: local
-    application.name: lhm_user_service
+    application.name: user-service
         
 logging:
   level:
@@ -58,5 +58,5 @@ security:
 spring:
     profiles: no-security
 
-server.port: 8870
+server.port: 8080
 security.ignored: /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,12 +8,6 @@ spring:
     profiles.active: local
     application.name: user-service
         
-logging:
-  level:
-    org.springframework.security: DEBUG
-    org.springframework.web: DEBUG
-    de.muenchen.referenzarchitektur: DEBUG
-
 ---
 # DOCKER CONFIGURATION
 spring:
@@ -29,10 +23,12 @@ server.port: 8080
 spring:
     profiles: local
     
-# random server port to avoid port 
-# conflicts on localhost
-# server.port: 0
-# dedicated server port
+logging:
+  level:
+    org.springframework.security: DEBUG
+    org.springframework.web: DEBUG
+    de.muenchen.referenzarchitektur: DEBUG
+    
 server.port: 8870
         
 
@@ -49,14 +45,18 @@ security:
     client:
       client-id: openIdDemo
 
-    #this part not needed when validating the JWT with the public key
-#    client:
-#    resource:
-#      userInfoUri: http://localhost:8080/auth/realms/demo/protocol/openid-connect/userinfo 
 
 ---
+# NO-SECURITY CONFIGURATION
 spring:
     profiles: no-security
 
-server.port: 8080
 security.ignored: /**
+server.port: 8870
+
+---
+# OPENSHIFT CONFIGURATION
+spring:
+    profiles: openshift
+
+server.port: 8080


### PR DESCRIPTION
Benötigt die Branches "openshift" von
- html5
- api-gateway
- admin-service
- user-service

Es gibt nun ein neues Profil "openshift". Dieses lässt sich wie folgt nutzen:

1. Lokal starten ohne Security
mvn spring-boot:run -Dspring.profiles.active=local,no-security

2. Lokal starten mit Security
mvn spring-boot:run
(Profil "local" ist das Standardprofil)

3. Auf Openshift starten ohne Security
mvn spring-boot:run -Dspring.profiles.active=openshift,no-security

(zukünftig, noch nicht in diesem PR, kommt dann noch
4. Auf Openshift starten mit Security
mvn spring-boot:run -Dspring.profiles.active=openshift
oder sogar (wenn wir das Standard-Profil auf "openshift" stellen)
mvn spring-boot:run)

**Achtung:**
mvn spring-boot:run -Dspring.profiles.active=no-security
ist KEINE valide Option mehr.